### PR TITLE
Creates container-based Molecule scenarios for building

### DIFF
--- a/molecule/container/Dockerfile.j2
+++ b/molecule/container/Dockerfile.j2
@@ -1,0 +1,9 @@
+# Molecule managed
+
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi

--- a/molecule/container/Dockerfile.j2
+++ b/molecule/container/Dockerfile.j2
@@ -9,8 +9,10 @@ RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && a
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi
 
 
-RUN apt-get install -y sudo
+RUN apt-get install -y sudo paxctl
 RUN adduser --disabled-password vagrant
 RUN usermod -aG sudo vagrant
+
+RUN paxctl -cm /usr/bin/python2.7
 
 USER vagrant

--- a/molecule/container/Dockerfile.j2
+++ b/molecule/container/Dockerfile.j2
@@ -7,3 +7,10 @@ RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && a
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi
+
+
+RUN apt-get install -y sudo
+RUN adduser --disabled-password vagrant
+RUN usermod -aG sudo vagrant
+
+USER vagrant

--- a/molecule/container/INSTALL.rst
+++ b/molecule/container/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Install
+*******
+
+Requirements
+============
+
+* Docker Engine
+* docker-py
+
+Install
+=======
+
+.. code-block:: bash
+
+  $ sudo pip install docker-py

--- a/molecule/container/create.yml
+++ b/molecule/container/create.yml
@@ -1,0 +1,47 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: platforms
+
+    - name: Discover local Docker images
+      docker_image_facts:
+        name: "molecule_local/{{ item.item.name }}"
+      with_items: "{{ platforms.results }}"
+      register: docker_images
+
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        name: "molecule_local/{{ item.item.image }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force: "{{ item.item.force | default(True) }}"
+      with_items: "{{ platforms.results }}"
+      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.name }}"
+        image: "molecule_local/{{ item.image }}"
+        state: started
+        recreate: False
+        log_driver: syslog
+        command: "{{ item.command | default('sleep infinity') }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
+      with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/container/destroy.yml
+++ b/molecule/container/destroy.yml
@@ -1,0 +1,16 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(True) }}"
+      with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/container/molecule.yml
+++ b/molecule/container/molecule.yml
@@ -6,8 +6,8 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: grsecurity-build-debian-stretch
-    image: debian:stretch
+  - name: grsecurity-build-debian-jessie
+    image: debian:jessie
   - name: grsecurity-build-ubuntu-trusty
     image: ubuntu:trusty
 provisioner:

--- a/molecule/container/molecule.yml
+++ b/molecule/container/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: grsecurity-build-debian-stretch
+    image: debian:stretch
+  - name: grsecurity-build-ubuntu-trusty
+    image: ubuntu:trusty
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: container
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/container/playbook.yml
+++ b/molecule/container/playbook.yml
@@ -1,6 +1,20 @@
 ---
-- name: Converge
+- name: Bootstrap user env.
   hosts: all
+  remote_user: root
+  tasks:
+    - name: Set passwordless sudo.
+      lineinfile:
+        dest: /etc/sudoers
+        regexp: '^%sudo'
+        line: '%sudo ALL=(ALL) NOPASSWD:ALL'
+        validate: '/usr/sbin/visudo -cf %s'
+
+- name: Configure kernel build.
+  hosts: all
+  remote_user: vagrant
+  environment:
+    USER: vagrant
   pre_tasks:
     # You can set these values via env vars:
     #
@@ -14,6 +28,7 @@
         that:
           - grsecurity_build_download_username != ''
           - grsecurity_build_download_password != ''
+
   roles:
     - role: ansible-role-grsecurity-build
       grsecurity_build_patch_type: stable2

--- a/molecule/container/playbook.yml
+++ b/molecule/container/playbook.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  pre_tasks:
+    # You can set these values via env vars:
+    #
+    #   * GRSECURITY_USERNAME
+    #   * GRSECURITY_PASSWORD
+    #
+    # The role will then automatically pick them up and these assert
+    # statements will pass.
+    - name: Check for grsecurity login credentials.
+      assert:
+        that:
+          - grsecurity_build_download_username != ''
+          - grsecurity_build_download_password != ''
+  roles:
+    - role: ansible-role-grsecurity-build
+      grsecurity_build_patch_type: stable2
+      grsecurity_build_strategy: manual

--- a/molecule/container/prepare.yml
+++ b/molecule/container/prepare.yml
@@ -1,0 +1,5 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: False
+  tasks: []

--- a/molecule/container/tests/test_default.py
+++ b/molecule/container/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/molecule/install/INSTALL.rst
+++ b/molecule/install/INSTALL.rst
@@ -1,0 +1,17 @@
+*******
+Install
+*******
+
+Requirements
+============
+
+* Vagrant
+* Virtualbox, Parallels, VMware Fusion, VMware Workstation or VMware Desktop
+* python-vagrant
+
+Install
+=======
+
+.. code-block:: bash
+
+  $ sudo pip install python-vagrant

--- a/molecule/install/create.yml
+++ b/molecule/install/create.yml
@@ -1,0 +1,56 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_instance_config: "{{ lookup('env', 'MOLECULE_INSTANCE_CONFIG') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Create molecule instance(s)
+      molecule_vagrant:
+        instance_name: "{{ item.name }}"
+        instance_interfaces: "{{ item.interfaces | default(omit) }}"
+        instance_raw_config_args: "{{ item.instance_raw_config_args | default(omit) }}"
+
+        platform_box: "{{ item.box }}"
+        platform_box_version: "{{ item.box_version | default(omit) }}"
+        platform_box_url: "{{ item.box_url | default(omit) }}"
+
+        provider_name: "{{ molecule_yml.driver.provider.name }}"
+        provider_memory: "{{ item.memory | default(omit) }}"
+        provider_cpus: "{{ item.cpus | default(omit) }}"
+        provider_raw_config_args: "{{ item.raw_config_args | default(omit) }}"
+
+        state: up
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config dict
+      set_fact:
+        instance_conf_dict: {
+          'instance': "{{ item.Host }}",
+          'address': "{{ item.HostName }}",
+          'user': "{{ item.User }}",
+          'port': "{{ item.Port }}",
+          'identity_file': "{{ item.IdentityFile }}", }
+      with_items: "{{ server.results }}"
+      register: instance_config_dict
+      when: server.changed | bool
+
+    - name: Convert instance config dict to a list
+      set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+      when: server.changed | bool
+
+    - name: Dump instance config
+      copy:
+        # NOTE(retr0h): Workaround for Ansible 2.2.
+        #               https://github.com/ansible/ansible/issues/20885
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/molecule/install/destroy.yml
+++ b/molecule/install/destroy.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_instance_config: "{{ lookup('env',' MOLECULE_INSTANCE_CONFIG') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      molecule_vagrant:
+        instance_name: "{{ item.name }}"
+        platform_box: "{{ item.box }}"
+        provider_name: "{{ molecule_yml.driver.provider.name }}"
+        force_stop: "{{ item.force_stop | default(True) }}"
+
+        state: destroy
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        # NOTE(retr0h): Workaround for Ansible 2.2.
+        #               https://github.com/ansible/ansible/issues/20885
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+lint:
+  name: yamllint
+platforms:
+  - name: grsecurity-install
+    box: debian/stretch64
+    instance_raw_config_args:
+      - "vm.synced_folder './', '/vagrant', disabled: true"
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: install
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/install/playbook.yml
+++ b/molecule/install/playbook.yml
@@ -1,0 +1,21 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+  pre_tasks:
+    - name: Find local deb packages.
+      become: no
+      delegate_to: localhost
+      find:
+        paths:
+          - "{{ molecule_scenario_directory+'/../grsec-build-container' }}"
+        patterns:
+          - '*-image-*.deb'
+      register: grsec_deb_packages_result
+
+    - debug: var=grsec_deb_packages_result
+
+  roles:
+    - role: ~/freedomofpress/ansible-role-grsecurity-install
+      grsecurity_install_deb_packages: "{{ grsec_deb_packages_result.files|map(attribute='path')|list }}"

--- a/molecule/install/prepare.yml
+++ b/molecule/install/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      become: True
+      changed_when: False

--- a/molecule/install/tests/test_default.py
+++ b/molecule/install/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,2 +1,3 @@
 molecule>=2.4
 python-vagrant
+docker-py


### PR DESCRIPTION
**Depends on #3—review and merge #3 first.**

Supplements the work in #3 by providing a separate scenario for using container images to build kernels. Use of containers neatly sidesteps the problem of limited disk space in certain Vagrant base boxes (e.g. debian/stretch64), and also makes testing multiple platforms more straightforward.

There's no support for fully unattended builds right now—the build strategy is still set to manual—but that's good enough for testing the apt package installation logic, which varies widely by platform. In subsequent PRs we can bundle a minimal kernel config and kick off a test build with that locally by setting the `grsecurity_build_custom_config` var at the play-level.

Also satisfies #1, as did #3.