### PR TITLE
Supports copying local grsecurity patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .molecule/
+
+# Ignore any local grsecurity patches (and associated GPG signatures)
+*.patch
+*.patch.sig

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,13 @@ grsecurity_build_fetch_packages_dest: "./"
 grsecurity_build_download_username: "{{ lookup('env', 'GRSECURITY_USERNAME')|default('') }}"
 grsecurity_build_download_password: "{{ lookup('env', 'GRSECURITY_PASSWORD')|default('') }}"
 
+# Filepath to local grsecurity patch file on the Ansible controller, for copying
+# to remote build host. Sidesteps need for authenticated network calls on every
+# run of the role. Assumes the patch file is the latest, since it must match
+# a specific kernel version.
+grsecurity_build_patch_filename: ''
+grsecurity_build_patch_sig_filename: "{{ grsecurity_patch_filename }}.sig"
+
 # List of GPG keys required for building grsecurity-patched kernel.
 grsecurity_build_gpg_keys:
   - name: Greg Kroah-Hartman GPG key (Linux stable release signing key)

--- a/molecule/container/playbook.yml
+++ b/molecule/container/playbook.yml
@@ -28,6 +28,10 @@
         that:
           - grsecurity_build_download_username != ''
           - grsecurity_build_download_password != ''
+      # Don't try authenticated network calls if we have the patch files
+      # locally already.
+      when: grsecurity_build_patch_filename is not defined
+            or grsecurity_build_patch_filename == ''
 
   roles:
     - role: ansible-role-grsecurity-build

--- a/tasks/copy_grsecurity_files.yml
+++ b/tasks/copy_grsecurity_files.yml
@@ -1,0 +1,11 @@
+---
+# Not using get_url because it doesn't follow redirects.
+- name: Copy grsecurity patch.
+  copy:
+    src: "{{ grsecurity_build_patch_filename }}"
+    dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_build_patch_filename }}"
+
+- name: Copy grsecurity signature.
+  copy:
+    src: "{{ grsecurity_build_patch_sig_filename }}"
+    dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_build_patch_sig_filename }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,12 @@
 - include: fetch_linux_kernel_source.yml
 
 - include: fetch_grsecurity_files.yml
+  when: grsecurity_build_patch_filename is not defined or
+        not grsecurity_build_patch_filename
+
+- include: copy_grsecurity_files.yml
+  when: grsecurity_build_patch_filename is defined and
+        grsecurity_build_patch_filename != ''
 
 - include: fetch_ubuntu_overlay.yml
   tags: ubuntu_overlay


### PR DESCRIPTION
Reduces number of unnecessary network calls fetching patches when they've
already been fetched once. Normally we could trust Ansible `get_url` module
to provide idempotence, but we're instead using `command to call curl for
better authentication support.

Signature filename is assumed to be the patch filename + '.sig', which
is reasonable. Tempted to use an env var. Hate that we can't commit
these GPL'd files directly....

Ignores local patch files via `.gitignore` to prevent any accidents.

Doesn't make authenticated network calls if a local patch file is
declared, which enables runs of the role without subscription access, as
long as the patch file has been provided out of band.

Closes #4.