### PR TITLE
Creates meta/main.yml role info file

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  author: Conor Schaefer (@conorsch)
+  description: Builds grsecurity-patched Linux kernel images
+  company: Freedom of the Press Foundation (@freedomofpress)
+  license: MIT
+  min_ansible_version: 2.4
+  platforms:
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
+  categories:
+    - kernel
+    - linux
+    - packaging
+    - system
+dependencies: []


### PR DESCRIPTION
Required for installing via Ansible galaxy, even as part of a Molecule
dependency run.

Closes #12.