### PR TITLE
Concurrent compile and root detection fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,9 +46,15 @@ grsecurity_build_use_ccache: true
 # it would be: `4.4.32-grsec-3.1.201611150755`.
 grsecurity_build_revision: "{{ linux_kernel_version }}-grsec-{{ grsecurity_version }}.{{ grsecurity_patch_timestamp }}"
 
+# Number of concurrent workers to spin up; this is piped to the make '-j'
+# option. If you set this variable to blank, the number of jobs running
+# concurrently will be infinite. Default number if based off the number of cores
+# ansible determines you have.
+grsecurity_build_compile_jobs: "{{ ansible_processor_vcpus }}"
+
 # The command to run to perform the compilation. Does not include environment
 # variables, such as PATH munging for ccache and setting workers to number of VCPUs.
-grsecurity_build_compile_command: make deb-pkg
+grsecurity_build_compile_command: "make -j{{grsecurity_build_compile_jobs}} deb-pkg"
 
 # Whether built .deb files should be fetched back to the Ansible controller.
 # Useful when compiling remotely, but not so much on a local workstation.
@@ -109,7 +115,6 @@ grsecurity_build_custom_config_applydiff: ''
 
 # Default compile build environmental variables
 grsecurity_build_env_vars:
-      CONCURRENCY_LEVEL: "{{ ansible_processor_vcpus }}"
       # Conditionally enable ccache by prepending the ccache lib directory
       # to PATH, which will override the system gcc and and g++ binaries.
       PATH: "{% if grsecurity_build_use_ccache == true %}/usr/lib/ccache:{% endif %}{{ ansible_env.PATH }}"

--- a/tasks/become_check.yml
+++ b/tasks/become_check.yml
@@ -1,0 +1,13 @@
+---
+- name: Run setup as same user as role
+  setup:
+
+- name: Stop if running with elevated privileges.
+  fail:
+    msg: >-
+      WARNING! You should not compile the Linux kernel with
+      superuser privileges. Doing so may create an unbootable
+      system. See Greg Kroah-Hartman's Linux Kernel in a Nutshell
+      for anecdotes about how doing so has broken systems
+      in the past: http://www.kroah.com/lkn/
+  when: ansible_user_id == 'root'

--- a/tasks/main-stable.yml
+++ b/tasks/main-stable.yml
@@ -1,14 +1,4 @@
 ---
-- name: Stop if running with elevated privileges.
-  fail:
-    msg: >-
-      WARNING! You should not compile the Linux kernel with
-      superuser privileges. Doing so may create an unbootable
-      system. See Greg Kroah-Hartman's Linux Kernel in a Nutshell
-      for anecdotes about how doing so has broken systems
-      in the past: http://www.kroah.com/lkn/
-  when: ansible_env.USER == 'root'
-
   # Install packages before fetching dynamic URLs, since python-requests
   # is required by the URL-fetching Ansible module.
 - include: packages.yml

--- a/tasks/main-unofficial.yml
+++ b/tasks/main-unofficial.yml
@@ -1,14 +1,4 @@
 ---
-- name: Stop if running with elevated privileges.
-  fail:
-    msg: >-
-      WARNING! You should not compile the Linux kernel with
-      superuser privileges. Doing so may create an unbootable
-      system. See Greg Kroah-Hartman's Linux Kernel in a Nutshell
-      for anecdotes about how doing so has broken systems
-      in the past: http://www.kroah.com/lkn/
-  when: ansible_env.USER == 'root'
-
 - name: Install stretch backports repository.
   become: yes
   apt_repository:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: become_check.yml
+
 - include: main-stable.yml
   when: grsecurity_build_patch_type != 'unofficial'
 


### PR DESCRIPTION
Two issues addressed in this PR

* concurrent compile job was lost with the switch to `make deb-pkg` as the default build command. This PR now passes as `-j` option to that command
* Fixes #17 - was failing for me under docker. Switches to using an ansible var (as opposed to a user environment variable) and centralizes the logic (since it applies to both the unofficial and stable targets).