### PR TITLE
Prepend fakeroot to compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ grsecurity_build_revision: "{{ linux_kernel_version }}-grsec-{{ grsecurity_versi
 
 # The command to run to perform the compilation. Does not include environment
 # variables, such as PATH munging for ccache and setting workers to number of VCPUs.
-grsecurity_build_compile_command: make deb-pkg
+grsecurity_build_compile_command: fakeroot make deb-pkg
 
 # Whether built .deb files should be fetched back to the Ansible controller.
 # Useful when compiling remotely, but not so much on a local workstation.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,7 +55,7 @@ grsecurity_build_compile_jobs: "{{ ansible_processor_vcpus }}"
 
 # The command to run to perform the compilation. Does not include environment
 # variables, such as PATH munging for ccache and setting workers to number of VCPUs.
-grsecurity_build_compile_command: "make -j{{grsecurity_build_compile_jobs}} deb-pkg"
+grsecurity_build_compile_command: "fakeroot make -j{{grsecurity_build_compile_jobs}} deb-pkg"
 
 # Whether built .deb files should be fetched back to the Ansible controller.
 # Useful when compiling remotely, but not so much on a local workstation.


### PR DESCRIPTION
Building with fakeroot is standard practice in all Debian package build systems. Their online wikis are probably the best source for that, but [here's another reference for explanation](https://unix.stackexchange.com/questions/9714/what-is-the-need-for-fakeroot-command-in-linux).
It's already included in depdendencies, so no special considerations.