### PR TITLE
Add retry logic for grsec patch retrieval

### DIFF
--- a/tasks/fetch_grsecurity_files.yml
+++ b/tasks/fetch_grsecurity_files.yml
@@ -7,8 +7,13 @@
     password: "{{ grsecurity_build_download_password if grsecurity_build_patch_type.startswith('stable') else omit }}"
     dest: "{{ item.dest }}"
     creates: "{{ item.dest }}"
+    status_code: 200
   with_items:
     - url: "{{ grsecurity_patch_url }}"
       dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
     - url: "{{ grsecurity_signature_url  }}"
       dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"
+  register: _fetch_grsec_results
+  delay: 15
+  retries: 5
+  until: _fetch_grsec_results.failed is not defined


### PR DESCRIPTION
This particularly bit of logic seems to have a high failure rate when
run in CI. In order to try and make it more resilient, add in retry
logic to ensure we give it a couple rounds before giving it up.

In order to test I made the following temporary modifications:

```yaml
---

- pause:
    seconds: 20
  tags: grsec_fetch

- name: Fetch grsecurity patch and signature
  uri:
    url: "{{ item.url }}"
    force_basic_auth: yes
    user: "{{ grsecurity_build_download_username if grsecurity_build_patch_type.startswith('stable') else omit }}"
    password: "{{ grsecurity_build_download_password if grsecurity_build_patch_type.startswith('stable') else omit }}"
    dest: "{{ item.dest }}"
    creates: "{{ item.dest }}"
    status_code: 200
  with_items:
    - url: "{{ grsecurity_patch_url }}"
      dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
    - url: "{{ grsecurity_signature_url  }}"
      dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"
  register: _fetch_grsec_results
  ignore_errors: true
  delay: 15
  retries: 5
  until: _fetch_grsec_results.failed is not defined
  tags: grsec_fetch
```

then i ran `molecule converge -s ci-official-stable3 -- -t grsec_fetch`. as soon as the pause hits, you quickly jump in the container and write this line into /etc/hosts `127.0.0.1    grsecurity.net`. Let it fail a few times, and then comment it and make sure it recovers.

You might be asking... why cant I just put that line in etc/hosts right away? well because the grsecurity_urls module needs to run first and we cant have that bomb out.