### PR TITLE
Build SecureDrop kernels with docker image

### DIFF
--- a/molecule/securedrop-docker/Dockerfile.j2
+++ b/molecule/securedrop-docker/Dockerfile.j2
@@ -1,0 +1,18 @@
+# Molecule managed
+
+FROM {{ item.image }}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates libssl-dev libelf-dev && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python python-devel python2-dnf bash libssl-dev libelf-dev&& dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml  libssl-dev libelf-dev && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates libssl-dev libelf-dev; fi
+
+
+RUN apt-get install -y sudo paxctl
+RUN adduser --disabled-password vagrant
+RUN usermod -aG sudo vagrant
+
+RUN paxctl -cm /usr/bin/python2.7
+
+USER vagrant

--- a/molecule/securedrop-docker/create.yml
+++ b/molecule/securedrop-docker/create.yml
@@ -1,0 +1,47 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
+    molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Create Dockerfiles from image names
+      template:
+        src: "{{ molecule_scenario_directory }}/Dockerfile.j2"
+        dest: "{{ molecule_ephemeral_directory }}/Dockerfile_{{ item.image | regex_replace('[^a-zA-Z0-9_]', '_') }}"
+      with_items: "{{ molecule_yml.platforms }}"
+      register: platforms
+
+    - name: Discover local Docker images
+      docker_image_facts:
+        name: "molecule_local/{{ item.item.name }}"
+      with_items: "{{ platforms.results }}"
+      register: docker_images
+
+    - name: Build an Ansible compatible image
+      docker_image:
+        path: "{{ molecule_ephemeral_directory }}"
+        name: "molecule_local/{{ item.item.image }}"
+        dockerfile: "{{ item.item.dockerfile | default(item.invocation.module_args.dest) }}"
+        force: "{{ item.item.force | default(True) }}"
+      with_items: "{{ platforms.results }}"
+      when: platforms.changed or docker_images.results | map(attribute='images') | select('equalto', []) | list | count >= 0
+
+    - name: Create molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        hostname: "{{ item.name }}"
+        image: "molecule_local/{{ item.image }}"
+        state: started
+        recreate: False
+        log_driver: syslog
+        command: "{{ item.command | default('sleep infinity') }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        capabilities: "{{ item.capabilities | default(omit) }}"
+      with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/securedrop-docker/create.yml
+++ b/molecule/securedrop-docker/create.yml
@@ -9,6 +9,16 @@
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  pre_tasks:
+    - name: Inspect kernel configuration for presence of Retpoline setting
+      shell: "grep 'CONFIG_RETPOLINE=y' /boot/config-$(uname -r)"
+      register: retpoline_config
+
+    - name: Fetch running kernel version
+      assert:
+        that:
+          - retpoline_config.rc == 0
+        msg: "A retpoline-enabled kernel must be used for full Spectre v2 mitigations"
   tasks:
     - name: Create Dockerfiles from image names
       template:

--- a/molecule/securedrop-docker/create.yml
+++ b/molecule/securedrop-docker/create.yml
@@ -3,7 +3,6 @@
   hosts: localhost
   connection: local
   gather_facts: False
-  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"

--- a/molecule/securedrop-docker/destroy.yml
+++ b/molecule/securedrop-docker/destroy.yml
@@ -1,0 +1,16 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  vars:
+    molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
+    molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
+  tasks:
+    - name: Destroy molecule instance(s)
+      docker_container:
+        name: "{{ item.name }}"
+        state: absent
+        force_kill: "{{ item.force_kill | default(True) }}"
+      with_items: "{{ molecule_yml.platforms }}"

--- a/molecule/securedrop-docker/destroy.yml
+++ b/molecule/securedrop-docker/destroy.yml
@@ -3,7 +3,6 @@
   hosts: localhost
   connection: local
   gather_facts: False
-  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"

--- a/molecule/securedrop-docker/molecule.yml
+++ b/molecule/securedrop-docker/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: grsecurity-build-securedrop-trusty
+    image: ubuntu:xenial
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: securedrop-docker
+  test_sequence:
+    # Far too many linting violations, punting on cleanup.
+    # - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - converge
+    # No tests written yet, punting for now.
+    # - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/securedrop-docker/playbook.yml
+++ b/molecule/securedrop-docker/playbook.yml
@@ -1,0 +1,36 @@
+---
+- name: Bootstrap user env.
+  hosts: all
+  remote_user: root
+  tasks:
+    - name: Set passwordless sudo.
+      lineinfile:
+        dest: /etc/sudoers
+        regexp: '^%sudo'
+        line: '%sudo ALL=(ALL) NOPASSWD:ALL'
+        validate: '/usr/sbin/visudo -cf %s'
+
+- name: Configure kernel build.
+  hosts: all
+  pre_tasks:
+    # You can set these values via env vars:
+    #
+    #   * GRSECURITY_USERNAME
+    #   * GRSECURITY_PASSWORD
+    #
+    # The role will then automatically pick them up and these assert
+    # statements will pass.
+    - name: Check for grsecurity login credentials.
+      assert:
+        that:
+          - grsecurity_build_download_username != ''
+          - grsecurity_build_download_password != ''
+
+  remote_user: vagrant
+  environment:
+    USER: vagrant
+  roles:
+    - role: ansible-role-grsecurity-build
+      grsecurity_build_patch_type: stable2
+      grsecurity_build_custom_config: config-securedrop-4.4
+      tags: kernel

--- a/vars/Ubuntu_xenial.yml
+++ b/vars/Ubuntu_xenial.yml
@@ -1,0 +1,13 @@
+---
+grsecurity_build_apt_packages:
+  - bc
+  - build-essential
+  - fakeroot
+  - g++-5
+  - gcc-5
+  - gcc-5-plugin-dev
+  - kernel-package
+  - libncurses5-dev
+  - libssl-dev
+  - make
+  - python-requests


### PR DESCRIPTION
Introduce a new scenario for building SecureDrop kernels with Docker.

Full Spectre mitigations have been backported and introduced in 4.4.118. However GCC RAP plugin build fails with gcc 4.8.4-2 from Ubuntu 14.04, so Ubuntu Xenial is required to build the Kernel image at the moment (4.4.120).
The produced kernel has been tested and if functional on SecureDrop production vms (14.04).
Added a test to ensure retpoline is supported in the current.