### PR TITLE
Creates "securedrop-rebuild" scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 *.deb
 *.tar.gz
 *.pyc
+
+# No Ansible retry files
+*.retry

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := help
+
+.PHONY: securedrop-rebuild
+securedrop-rebuild: ## Rebuilds SecureDrop kernels from source tarball.
+# Not using `molecule converge` since we can't also use `vars_prompt`
+# to ask for the source tarball.
+	@molecule create -s securedrop-rebuild
+	@ansible-playbook -vv --diff molecule/securedrop-rebuild/playbook.yml \
+		-i molecule/securedrop-rebuild/.molecule/ansible_inventory.yml
+
+.PHONY: help
+help: ## Prints this message and exits.
+	@printf "Subcommands:\n\n"
+	@perl -F':.*##\s+' -lanE '$$F[1] and say "\033[36m$$F[0]\033[0m : $$F[1]"' $(MAKEFILE_LIST) \
+		| sort \
+		| column -s ':' -t

--- a/molecule/securedrop-rebuild/Dockerfile.j2
+++ b/molecule/securedrop-rebuild/Dockerfile.j2
@@ -1,0 +1,1 @@
+../securedrop-docker/Dockerfile.j2

--- a/molecule/securedrop-rebuild/create.yml
+++ b/molecule/securedrop-rebuild/create.yml
@@ -1,0 +1,1 @@
+../securedrop-docker/create.yml

--- a/molecule/securedrop-rebuild/destroy.yml
+++ b/molecule/securedrop-rebuild/destroy.yml
@@ -1,0 +1,1 @@
+../securedrop-docker/destroy.yml

--- a/molecule/securedrop-rebuild/molecule.yml
+++ b/molecule/securedrop-rebuild/molecule.yml
@@ -1,0 +1,31 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: grsecurity-rebuild-securedrop-trusty
+    image: ubuntu:xenial
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: securedrop-rebuild
+  test_sequence:
+    # Far too many linting violations, punting on cleanup.
+    # - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - converge
+    # No tests written yet, punting for now.
+    # - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/securedrop-rebuild/playbook.yml
+++ b/molecule/securedrop-rebuild/playbook.yml
@@ -1,0 +1,74 @@
+---
+- name: Bootstrap user env.
+  hosts: all
+  remote_user: root
+  tasks:
+    - name: Set passwordless sudo.
+      lineinfile:
+        dest: /etc/sudoers
+        regexp: '^%sudo'
+        line: '%sudo ALL=(ALL) NOPASSWD:ALL'
+        validate: '/usr/sbin/visudo -cf %s'
+
+- name: Configure kernel build.
+  hosts: all
+  remote_user: vagrant
+  environment:
+    USER: vagrant
+  vars_prompt:
+    - name: source_tarball
+      prompt: Fullpath to source tarball
+      private: no
+      # Providing a default even though the var is required to provide
+      # better failure messages. If run via Molecule, Ansible will not
+      # prompt via `vars_prompt`; ansible-playbook must be called directly.
+      default: ''
+  tasks:
+    - name: Confirm tarball is fullpath.
+      assert:
+        that:
+          - "source_tarball is defined"
+          - "source_tarball != ''"
+          - "source_tarball.startswith('/')"
+        msg: Source tarball must be a fullpath.
+
+    - name: Copy source tarball to container.
+      unarchive:
+        src: "{{ source_tarball }}"
+        dest: "/home/vagrant/"
+        remote_src: false
+
+    - name: Find directory name of extracted source.
+      find:
+        paths:
+          - /home/vagrant
+        patterns:
+          - 'linux-*-grsec'
+        file_type: directory
+        recurse: no
+      register: extracted_source_dir_result
+
+    - name: Ensure we found exactly one directory.
+      assert:
+        that: extracted_source_dir_result.files|length == 1
+        msg: >-
+          Could not determine directory for extracted source.
+          Log in interactively and proceed with rebuilding.
+
+    # There's some duplication here with the role logic; rather than support
+    # tarball-rebuilds formally in the role, reimplementing a few barebones
+    # tasks and skipping running the entire role.
+    - name: Import role vars for package names.
+      include_vars: "{{ playbook_dir }}/../../vars/{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+
+    - name: Install core build requirements.
+      become: yes
+      apt:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ grsecurity_build_apt_packages }}"
+
+    - name: Rebuild kernel from source.
+      command: make deb-pkg
+      args:
+        chdir: "{{ extracted_source_dir_result.files[0].path }}"

--- a/molecule/securedrop-rebuild/playbook.yml
+++ b/molecule/securedrop-rebuild/playbook.yml
@@ -15,6 +15,8 @@
   remote_user: vagrant
   environment:
     USER: vagrant
+  vars:
+    rebuild_directory: /home/vagrant
   vars_prompt:
     - name: source_tarball
       prompt: Fullpath to source tarball
@@ -41,7 +43,7 @@
     - name: Find directory name of extracted source.
       find:
         paths:
-          - /home/vagrant
+          - "{{ rebuild_directory }}"
         patterns:
           - 'linux-*-grsec'
         file_type: directory
@@ -72,3 +74,21 @@
       command: make deb-pkg
       args:
         chdir: "{{ extracted_source_dir_result.files[0].path }}"
+
+    - name: Find newly build kernel packages.
+      find:
+        paths:
+          - "{{ rebuild_directory }}"
+        patterns: "linux*.deb"
+      register: rebuild_find_packages_result
+      tags: fetch
+
+    - name: Fetch built kernel package back to localhost.
+      fetch:
+        src: "{{ item }}"
+        dest: ./
+        flat: yes
+        fail_on_missing: yes
+      with_items: "{{ rebuild_find_packages_result.files|map(attribute='path')|list }}"
+      tags:
+        - fetch


### PR DESCRIPTION
Designed to provide a streamlined process for rebuilding SecureDrop
kernels from source tarball. The build environment is fairly specific,
and although the tarball will have all necessary parts, folks still need
to install a handful of packages and copy around the tarball.

Adds Makefile

Just a single target: "securedrop-rebuild". Hacking together the
Molecule/Ansible logic to sidestep the lack of support for vars_prompt
when Ansible is run via Molecule, i.e. non-interactively.