### PR TITLE
Updates Molecule dependency to 2.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,6 @@ workflows:
   grsec_kernel_role:
     jobs:
       # Haven't gotten this one reliably passing yet
-      #- build-official
+      # - build-official
       - build-unofficial
       - build-minipli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ workflows:
   version: 2
   grsec_kernel_role:
     jobs:
-      - build-official
+      # Haven't gotten this one reliably passing yet
+      #- build-official
       - build-unofficial
       - build-minipli

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ansible
+ansible<2.5
 docker<3.0.0
-molecule
+molecule<2.16
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,69 +4,71 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-ansible-lint==3.4.19      # via molecule
-ansible==2.4.3.0
-anyconfig==0.9.1          # via molecule
+ansible-lint==3.4.21      # via molecule
+ansible==2.4.6.0
+anyconfig==0.9.4          # via molecule
 arrow==0.12.1             # via jinja2-time
 asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0             # via pytest
+atomicwrites==1.1.5       # via pytest
+attrs==18.1.0             # via pytest
 backports.functools-lru-cache==1.5  # via arrow
 backports.ssl-match-hostname==3.5.0.1  # via docker
 bcrypt==3.1.4             # via paramiko
 binaryornot==0.4.4        # via cookiecutter
-certifi==2018.1.18        # via requests
-cffi==1.11.4              # via bcrypt, cryptography, pynacl
+cerberus==1.1             # via molecule
+certifi==2018.4.16        # via requests
+cffi==1.11.5              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via binaryornot, requests
-click-completion==0.2.1   # via molecule
-click==6.7                # via click-completion, cookiecutter, git-url-parse, molecule, pip-tools, python-gilt
-colorama==0.3.7           # via molecule, python-gilt
+click-completion==0.3.1   # via molecule
+click==6.7                # via click-completion, cookiecutter, molecule, pip-tools, python-gilt
+colorama==0.3.9           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
-cookiecutter==1.5.1       # via molecule
-cryptography==2.1.4       # via ansible, paramiko
-docker-pycreds==0.2.1     # via docker
+cookiecutter==1.6.0       # via molecule
+cryptography==2.3         # via ansible, paramiko
+docker-pycreds==0.3.0     # via docker
 docker==2.7.0
 enum34==1.1.6             # via cryptography, flake8
 fasteners==0.14.1         # via python-gilt
 first==2.0.1              # via pip-tools
-flake8==3.3.0             # via molecule
+flake8==3.5.0             # via molecule
 funcsigs==1.0.2           # via pytest
 future==0.16.0            # via cookiecutter
-git-url-parse==1.0.2      # via python-gilt
-idna==2.6                 # via cryptography, requests
-ipaddress==1.0.19         # via cryptography, docker
+git-url-parse==1.1.0      # via python-gilt
+idna==2.7                 # via cryptography, requests
+ipaddress==1.0.22         # via cryptography, docker
 jinja2-time==0.2.0        # via cookiecutter
-jinja2==2.9.6             # via ansible, click-completion, cookiecutter, jinja2-time, molecule
+jinja2==2.10              # via ansible, click-completion, cookiecutter, jinja2-time, molecule
 markupsafe==1.0           # via jinja2
-marshmallow==2.13.5       # via molecule
 mccabe==0.6.1             # via flake8
-molecule==2.7.0
-monotonic==1.4            # via fasteners
-paramiko==2.4.0           # via ansible
-pathspec==0.5.5           # via yamllint
+molecule==2.15.0
+monotonic==1.5            # via fasteners
+more-itertools==4.2.0     # via pytest
+paramiko==2.4.1           # via ansible
+pathspec==0.5.6           # via yamllint
 pbr==3.0.1                # via git-url-parse, molecule, python-gilt
 pexpect==4.2.1            # via molecule
-pip-tools==1.11.0
+pip-tools==2.0.2
 pluggy==0.6.0             # via pytest
 poyo==0.4.1               # via cookiecutter
 psutil==5.2.2             # via molecule
-ptyprocess==0.5.2         # via pexpect
-py==1.5.2                 # via pytest
-pyasn1==0.4.2             # via paramiko
+ptyprocess==0.6.0         # via pexpect
+py==1.5.4                 # via pytest
+pyasn1==0.4.3             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
-pyflakes==1.5.0           # via flake8
+pyflakes==1.6.0           # via flake8
 pynacl==1.2.1             # via paramiko
-pytest==3.4.0             # via testinfra
-python-dateutil==2.6.1    # via arrow
-python-gilt==1.1.0        # via molecule
+pytest==3.6.3             # via testinfra
+python-dateutil==2.7.3    # via arrow
+python-gilt==1.2.1        # via molecule
 pyyaml==3.12              # via ansible, ansible-lint, molecule, python-gilt, yamllint
-requests==2.18.4          # via docker
+requests==2.19.1          # via cookiecutter, docker
 sh==1.12.14               # via molecule, python-gilt
-six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, fasteners, git-url-parse, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
-tabulate==0.7.7           # via molecule
-testinfra==1.7.1          # via molecule
+six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, fasteners, molecule, more-itertools, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
+tabulate==0.8.2           # via molecule
+testinfra==1.12.0         # via molecule
 tree-format==0.1.2        # via molecule
-urllib3==1.22             # via requests
-websocket-client==0.46.0  # via docker
+urllib3==1.23             # via requests
+websocket-client==0.48.0  # via docker
 whichcraft==0.4.1         # via cookiecutter
-yamllint==1.8.1           # via molecule
+yamllint==1.11.1          # via molecule


### PR DESCRIPTION
The previously pinned version, 2.7, has been removed from PyPI, so it wasn't possible to install any longer. 

Fixes #37.

As part of these changes, I've enabled branch restrictions to enforce CI on merge into master. We haven't done that before, so it may fail. Marking WIP until confirmed working.