### PR TITLE
Updates build dependencies on Stretch for 4.14.66

### DIFF
--- a/molecule/workstation/playbook.yml
+++ b/molecule/workstation/playbook.yml
@@ -31,4 +31,4 @@
   roles:
     - role: ansible-role-grsecurity-build
       grsecurity_build_patch_type: stable3
-      grsecurity_build_strategy: manual
+      grsecurity_build_strategy: workstation-4.14

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -6,7 +6,8 @@ grsecurity_build_apt_packages:
   - fakeroot
   - gcc-6
   - gcc-6-plugin-dev
+  - kmod
   - libncurses5-dev
+  - libssl-dev
   - make
   - python-requests
-  - libssl-dev


### PR DESCRIPTION
The first build I ran for 4.14.66 with stretch as build host failed due to lack of the `kmod` package. Adding it here. Haven't tested other platforms yet; it's likely a dependency of all builds tracking the stable3 patch set, but haven't confirmed.

Also enabled unattended-by-default builds for the workstation kernel config. 