### PR TITLE
Supports container scenarios under Qubes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ qvm-clone --class StandaloneVM <template_vm> kernel-builder
 qvm-volume resize kernel-builder:root 40G
 ```
 
+If you would prefer using Template-based AppVMs or DispVMs, you can clone an
+existing template with Docker installed/configured, and create either an AppVM
+or DispVM based on this template:
+
+```
+qvm-clone --class TemplateVM <template_vm> kernel-builder-template
+qvm-volume resize kernel-builder-template:root 40G
+# If you want to create AppVM
+qvm-create --template kernel-builder-template kernel-builder --label=red
+# If you would rather create a DispVM templte
+qvm-create --template kernel-builder-template kernel-builder-dvm
+qvm-prefs custom-dvm template_for_dispvms True
+qvm-features custom-dvm appmenus-dispvm 1
+```
+
 The 40GB recommendation is to account for the ~10GB already used by a root volume.
 For slimmer kernel configs, less disk space will be required to build.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Build documentation can be found in the `docs/build.md` file.
 ## Requirements
 
 ### Platforms
-Only Debian and Ubuntu are supported, due to the use of make-kpkg.
+Only Debian and Ubuntu are tested, but other platforms may work, as well.
 
 ### Resources
 For compiling the kernel, 2GB and 2 VCPUs is plenty. Depending on the config options
@@ -21,6 +21,18 @@ you specify, the compilation should take two to three hours on that hardware.
 Naturally, you can speed up the build by providing more resources.
 
 As for disk space, make sure you have at least 30GB to run the full kernel compile.
+
+If you wish to build under Qubes via one of the container-based Molecule scenarios,
+you'll need ample space on the root partition. Qubes does not support resizing root
+partitions of AppVMs, so create a StandAloneVM and grow its root volume:
+
+```
+qvm-clone --class StandaloneVM <template_vm> kernel-builder
+qvm-volume resize kernel-builder:root 40G
+```
+
+The 40GB recommendation is to account for the ~10GB already used by a root volume.
+For slimmer kernel configs, less disk space will be required to build.
 
 ### Credentials
 Furthermore, you must have a [grsecurity subscription] and export the

--- a/molecule/securedrop-docker/create.yml
+++ b/molecule/securedrop-docker/create.yml
@@ -9,9 +9,18 @@
     molecule_scenario_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}"
     molecule_yml: "{{ lookup('file', molecule_file) | molecule_from_yaml }}"
   pre_tasks:
-    - name: Inspect kernel configuration for presence of Retpoline setting
-      shell: "grep 'CONFIG_RETPOLINE=y' /boot/config-$(uname -r)"
-      register: retpoline_config
+    # Qubes hosts use a different filepath for kernel configs, try that
+    # path if the first path isn't found.
+    - block:
+        - name: Inspect kernel configuration for presence of Retpoline setting
+          shell: "grep 'CONFIG_RETPOLINE=y' /boot/config-$(uname -r)"
+          changed_when: false
+          register: retpoline_config
+      rescue:
+        - name: Inspect kernel configuration for presence of Retpoline setting (Qubes)
+          shell: "grep 'CONFIG_RETPOLINE=y' /lib/modules/$(uname -r)/build/.config"
+          changed_when: false
+          register: retpoline_config
 
     - name: Fetch running kernel version
       assert:


### PR DESCRIPTION
The kernel string version checks used a practical filepath
to retrieve the kernel config for the host machine, but that filepath
was wrong under Qubes. Added a try/except to run an additional check if
the first filepath wasn't found. Building SD kernels under Qubes via
the Molecule container-based scenario now works.

Adds a bit of documentation around the StandaloneVM templating.