### PR TITLE
Address CVE-2019-3462

### DIFF
--- a/molecule/ci-minipli/molecule.yml
+++ b/molecule/ci-minipli/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: grsec_build_jessie
-    image: debian:jessie
+    image: debian:jessie-20190204
 provisioner:
   name: ansible
   lint:

--- a/molecule/ci-official-stable3/molecule.yml
+++ b/molecule/ci-official-stable3/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: grsec_build_jessie
-    image: debian:jessie
+    image: debian:jessie-20190204
 provisioner:
   name: ansible
   lint:

--- a/molecule/ci-unofficial/molecule.yml
+++ b/molecule/ci-unofficial/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: grsec_build_jessie
-    image: debian:jessie
+    image: debian:jessie-20190204
 provisioner:
   name: ansible
   lint:

--- a/molecule/container/molecule.yml
+++ b/molecule/container/molecule.yml
@@ -7,9 +7,9 @@ lint:
   name: yamllint
 platforms:
   - name: grsecurity-build-debian-jessie
-    image: debian:jessie
+    image: debian:jessie-20190204
   - name: grsecurity-build-ubuntu-trusty
-    image: ubuntu:trusty
+    image: ubuntu:trusty-20190122
 provisioner:
   name: ansible
   lint:

--- a/molecule/securedrop-docker/molecule.yml
+++ b/molecule/securedrop-docker/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: grsecurity-build-securedrop-trusty
-    image: ubuntu:xenial
+    image: ubuntu:xenial-20190122
 provisioner:
   name: ansible
   lint:

--- a/molecule/securedrop-rebuild/molecule.yml
+++ b/molecule/securedrop-rebuild/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: grsecurity-rebuild-securedrop-trusty
-    image: ubuntu:xenial
+    image: ubuntu:xenial-20190122
 provisioner:
   name: ansible
   lint:

--- a/molecule/workstation/molecule.yml
+++ b/molecule/workstation/molecule.yml
@@ -7,7 +7,7 @@ lint:
   name: yamllint
 platforms:
   - name: grsecurity-build-stable3-stretch
-    image: debian:stretch
+    image: debian:stretch-20190204
 provisioner:
   name: ansible
   lint:


### PR DESCRIPTION
If a user has pulled the Debian/Ubuntu image prior to 20190122, the same image will be reused in the future since we do not pin versions of the image. We should explicitly specify the image version to include the apt fix.
Unfortunately this will mean that we should update these on occasion.
To test:

- [ ] Ensure the images specified are not vulnerable to CVE-2019-3462
- [ ] Ensure all Docker images in all scenarios have been updated