### PR TITLE
added patches for e1000e Kaby Lake support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -126,3 +126,8 @@ grsecurity_build_env_vars:
 
 # Additional env variables to pass to the build process
 grsecurity_build_env_vars_addtl: {}
+
+# e1000e i219 (Kaby Lake) support patches
+e1000e_i219_patch_filename: '9cd34b3a1cfd47692cbef8cb0761475021883e18.txt'
+e1000e_i219lm_patch_filename: 'f3ed935de059b83394c3ecf2c64c93b57c8915fe.txt'
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -132,5 +132,6 @@ e1000e_i219_patch_filename: '9cd34b3a1cfd47692cbef8cb0761475021883e18.txt'
 e1000e_i219lm_patch_filename: 'f3ed935de059b83394c3ecf2c64c93b57c8915fe.txt'
 
 # Provide filepaths to local patches to apply to the source tree prior to building.
-# By default, adds e1000e patches, but only for 4.4 kernels.
-grsecurity_build_custom_patches: "{{ [e1000e_i219_patch_filename, e1000e_i219lm_patch_filename] if grsecurity_build_patch_type == 'stable2' else [] }}"
+# By default, adds e1000e patches, but only for 4.4 kernels. Order is important!
+# Patches will be applied in the order they're declared in the list.
+grsecurity_build_custom_patches: "{{ [e1000e_i219lm_patch_filename, e1000e_i219_patch_filename] if grsecurity_build_patch_type == 'stable2' else [] }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -131,3 +131,6 @@ grsecurity_build_env_vars_addtl: {}
 e1000e_i219_patch_filename: '9cd34b3a1cfd47692cbef8cb0761475021883e18.txt'
 e1000e_i219lm_patch_filename: 'f3ed935de059b83394c3ecf2c64c93b57c8915fe.txt'
 
+# Provide filepaths to local patches to apply to the source tree prior to building.
+# By default, adds e1000e patches, but only for 4.4 kernels.
+grsecurity_build_custom_patches: "{{ [e1000e_i219_patch_filename, e1000e_i219lm_patch_filename] if grsecurity_build_patch_type == 'stable2' else [] }}"

--- a/files/9cd34b3a1cfd47692cbef8cb0761475021883e18.txt
+++ b/files/9cd34b3a1cfd47692cbef8cb0761475021883e18.txt
@@ -1,0 +1,50 @@
+From 9cd34b3a1cfd47692cbef8cb0761475021883e18 Mon Sep 17 00:00:00 2001
+From: Raanan Avargil <raanan.avargil@intel.com>
+Date: Tue, 22 Dec 2015 15:35:05 +0200
+Subject: e1000e: Initial support for KabeLake
+
+i219 (4) and i219 (5) are the next LOM generations that will be
+available on the next Intel platform (KabeLake).
+This patch provides the initial support for the devices.
+
+Signed-off-by: Raanan Avargil <raanan.avargil@intel.com>
+Tested-by: Aaron Brown <aaron.f.brown@intel.com>
+Signed-off-by: Jeff Kirsher <jeffrey.t.kirsher@intel.com>
+---
+ drivers/net/ethernet/intel/e1000e/hw.h     | 4 ++++
+ drivers/net/ethernet/intel/e1000e/netdev.c | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/drivers/net/ethernet/intel/e1000e/hw.h b/drivers/net/ethernet/intel/e1000e/hw.h
+index b3949d5bef5c..4e733bf1a38e 100644
+--- a/drivers/net/ethernet/intel/e1000e/hw.h
++++ b/drivers/net/ethernet/intel/e1000e/hw.h
+@@ -92,6 +92,10 @@ struct e1000_hw;
+ #define E1000_DEV_ID_PCH_SPT_I219_LM2		0x15B7	/* SPT-H PCH */
+ #define E1000_DEV_ID_PCH_SPT_I219_V2		0x15B8	/* SPT-H PCH */
+ #define E1000_DEV_ID_PCH_LBG_I219_LM3		0x15B9	/* LBG PCH */
++#define E1000_DEV_ID_PCH_SPT_I219_LM4		0x15D7
++#define E1000_DEV_ID_PCH_SPT_I219_V4		0x15D8
++#define E1000_DEV_ID_PCH_SPT_I219_LM5		0x15E3
++#define E1000_DEV_ID_PCH_SPT_I219_V5		0x15D6
+ 
+ #define E1000_REVISION_4	4
+ 
+diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
+index c71ba1bfc1ec..9b4ec13d9161 100644
+--- a/drivers/net/ethernet/intel/e1000e/netdev.c
++++ b/drivers/net/ethernet/intel/e1000e/netdev.c
+@@ -7452,6 +7452,10 @@ static const struct pci_device_id e1000_pci_tbl[] = {
+ 	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_LM2), board_pch_spt },
+ 	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_V2), board_pch_spt },
+ 	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_LBG_I219_LM3), board_pch_spt },
++	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_LM4), board_pch_spt },
++	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_V4), board_pch_spt },
++	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_LM5), board_pch_spt },
++	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_V5), board_pch_spt },
+ 
+ 	{ 0, 0, 0, 0, 0, 0, 0 }	/* terminate list */
+ };
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/files/f3ed935de059b83394c3ecf2c64c93b57c8915fe.txt
+++ b/files/f3ed935de059b83394c3ecf2c64c93b57c8915fe.txt
@@ -1,0 +1,106 @@
+From f3ed935de059b83394c3ecf2c64c93b57c8915fe Mon Sep 17 00:00:00 2001
+From: Raanan Avargil <raanan.avargil@intel.com>
+Date: Tue, 20 Oct 2015 17:13:01 +0300
+Subject: e1000e: initial support for i219-LM (3)
+
+i219-LM (3) is a LOM that will be available on systems with the
+Lewisburg Platform Controller Hub (PCH) chipset from Intel.
+This patch provides the initial support for the device.
+
+Signed-off-by: Raanan Avargil <raanan.avargil@intel.com>
+Tested-by: Aaron Brown <aaron.f.brown@intel.com>
+Signed-off-by: Jeff Kirsher <jeffrey.t.kirsher@intel.com>
+---
+ drivers/net/ethernet/intel/e1000e/hw.h      |  1 +
+ drivers/net/ethernet/intel/e1000e/ich8lan.c | 43 +++++++++++++++++++++--------
+ drivers/net/ethernet/intel/e1000e/netdev.c  |  1 +
+ 3 files changed, 34 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/ethernet/intel/e1000e/hw.h b/drivers/net/ethernet/intel/e1000e/hw.h
+index c9da4654e9ca..b3949d5bef5c 100644
+--- a/drivers/net/ethernet/intel/e1000e/hw.h
++++ b/drivers/net/ethernet/intel/e1000e/hw.h
+@@ -91,6 +91,7 @@ struct e1000_hw;
+ #define E1000_DEV_ID_PCH_SPT_I219_V		0x1570	/* SPT PCH */
+ #define E1000_DEV_ID_PCH_SPT_I219_LM2		0x15B7	/* SPT-H PCH */
+ #define E1000_DEV_ID_PCH_SPT_I219_V2		0x15B8	/* SPT-H PCH */
++#define E1000_DEV_ID_PCH_LBG_I219_LM3		0x15B9	/* LBG PCH */
+ 
+ #define E1000_REVISION_4	4
+ 
+diff --git a/drivers/net/ethernet/intel/e1000e/ich8lan.c b/drivers/net/ethernet/intel/e1000e/ich8lan.c
+index 64c1f3620033..a049e30639a1 100644
+--- a/drivers/net/ethernet/intel/e1000e/ich8lan.c
++++ b/drivers/net/ethernet/intel/e1000e/ich8lan.c
+@@ -3093,24 +3093,45 @@ static s32 e1000_valid_nvm_bank_detect_ich8lan(struct e1000_hw *hw, u32 *bank)
+ 	struct e1000_nvm_info *nvm = &hw->nvm;
+ 	u32 bank1_offset = nvm->flash_bank_size * sizeof(u16);
+ 	u32 act_offset = E1000_ICH_NVM_SIG_WORD * 2 + 1;
++	u32 nvm_dword = 0;
+ 	u8 sig_byte = 0;
+ 	s32 ret_val;
+ 
+ 	switch (hw->mac.type) {
+-		/* In SPT, read from the CTRL_EXT reg instead of
+-		 * accessing the sector valid bits from the nvm
+-		 */
+ 	case e1000_pch_spt:
+-		*bank = er32(CTRL_EXT)
+-		    & E1000_CTRL_EXT_NVMVS;
+-		if ((*bank == 0) || (*bank == 1)) {
+-			e_dbg("ERROR: No valid NVM bank present\n");
+-			return -E1000_ERR_NVM;
+-		} else {
+-			*bank = *bank - 2;
++		bank1_offset = nvm->flash_bank_size;
++		act_offset = E1000_ICH_NVM_SIG_WORD;
++
++		/* set bank to 0 in case flash read fails */
++		*bank = 0;
++
++		/* Check bank 0 */
++		ret_val = e1000_read_flash_dword_ich8lan(hw, act_offset,
++							 &nvm_dword);
++		if (ret_val)
++			return ret_val;
++		sig_byte = (u8)((nvm_dword & 0xFF00) >> 8);
++		if ((sig_byte & E1000_ICH_NVM_VALID_SIG_MASK) ==
++		    E1000_ICH_NVM_SIG_VALUE) {
++			*bank = 0;
+ 			return 0;
+ 		}
+-		break;
++
++		/* Check bank 1 */
++		ret_val = e1000_read_flash_dword_ich8lan(hw, act_offset +
++							 bank1_offset,
++							 &nvm_dword);
++		if (ret_val)
++			return ret_val;
++		sig_byte = (u8)((nvm_dword & 0xFF00) >> 8);
++		if ((sig_byte & E1000_ICH_NVM_VALID_SIG_MASK) ==
++		    E1000_ICH_NVM_SIG_VALUE) {
++			*bank = 1;
++			return 0;
++		}
++
++		e_dbg("ERROR: No valid NVM bank present\n");
++		return -E1000_ERR_NVM;
+ 	case e1000_ich8lan:
+ 	case e1000_ich9lan:
+ 		eecd = er32(EECD);
+diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
+index 772447306c13..775e38910681 100644
+--- a/drivers/net/ethernet/intel/e1000e/netdev.c
++++ b/drivers/net/ethernet/intel/e1000e/netdev.c
+@@ -7467,6 +7467,7 @@ static const struct pci_device_id e1000_pci_tbl[] = {
+ 	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_V), board_pch_spt },
+ 	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_LM2), board_pch_spt },
+ 	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_SPT_I219_V2), board_pch_spt },
++	{ PCI_VDEVICE(INTEL, E1000_DEV_ID_PCH_LBG_I219_LM3), board_pch_spt },
+ 
+ 	{ 0, 0, 0, 0, 0, 0, 0 }	/* terminate list */
+ };
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/tasks/copy_patches.yml
+++ b/tasks/copy_patches.yml
@@ -1,0 +1,10 @@
+---
+- name: Copy e1000e i219 support patch.
+  copy:
+    src: "{{ e1000e_i219_patch_filename }}"
+    dest: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219_patch_filename }}"
+
+- name: Copy e1000e i219lm support patch 
+  copy:
+    src: "{{ e1000e_i219lm_patch_filename }}"
+    dest: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219lm_patch_filename }}"

--- a/tasks/copy_patches.yml
+++ b/tasks/copy_patches.yml
@@ -1,10 +1,6 @@
 ---
-- name: Copy e1000e i219 support patch.
+- name: Copy custom patches (e.g. for e1000e support)
   copy:
-    src: "{{ e1000e_i219_patch_filename }}"
-    dest: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219_patch_filename }}"
-
-- name: Copy e1000e i219lm support patch 
-  copy:
-    src: "{{ e1000e_i219lm_patch_filename }}"
-    dest: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219lm_patch_filename }}"
+    src: "{{ item }}"
+    dest: "{{ grsecurity_build_download_directory }}/{{ item|basename }}"
+  with_items: "{{ grsecurity_build_custom_patches }}"

--- a/tasks/main-stable.yml
+++ b/tasks/main-stable.yml
@@ -16,9 +16,12 @@
 
 - import_tasks: fetch_linux_kernel_source.yml
 
+
 - import_tasks: fetch_grsecurity_files.yml
   when: grsecurity_build_patch_filename is not defined or
         not grsecurity_build_patch_filename
+
+- import_tasks: copy_patches.yml
 
 - import_tasks: copy_grsecurity_files.yml
   when: grsecurity_build_patch_filename is defined and

--- a/tasks/prepare_source_directory.yml
+++ b/tasks/prepare_source_directory.yml
@@ -11,19 +11,13 @@
     dest: "{{ grsecurity_build_download_directory }}/"
 
 
-- name: Apply e1000e i219lm patch.
+- name: Apply custom patches (e.g. for e1000e support)
   patch:
     remote_src: true
-    src: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219lm_patch_filename }}"
+    src: "{{ grsecurity_build_download_directory }}/{{ item|basename }}"
     basedir: "{{ grsecurity_build_linux_source_directory }}"
     strip: 1
-
-- name: Apply e1000e i219 patch.
-  patch:
-    remote_src: true
-    src: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219_patch_filename }}"
-    basedir: "{{ grsecurity_build_linux_source_directory }}"
-    strip: 1
+  with_items: "{{ grsecurity_build_custom_patches }}"
 
 - name: Apply grsecurity patch.
   patch:

--- a/tasks/prepare_source_directory.yml
+++ b/tasks/prepare_source_directory.yml
@@ -10,6 +10,21 @@
     src: "{{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}.tar"
     dest: "{{ grsecurity_build_download_directory }}/"
 
+
+- name: Apply e1000e i219lm patch.
+  patch:
+    remote_src: true
+    src: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219lm_patch_filename }}"
+    basedir: "{{ grsecurity_build_linux_source_directory }}"
+    strip: 1
+
+- name: Apply e1000e i219 patch.
+  patch:
+    remote_src: true
+    src: "{{ grsecurity_build_download_directory }}/{{ e1000e_i219_patch_filename }}"
+    basedir: "{{ grsecurity_build_linux_source_directory }}"
+    strip: 1
+
 - name: Apply grsecurity patch.
   patch:
     remote_src: true


### PR DESCRIPTION
(Work in progress)

Adds two kernel patches for e1000e driver support on 7th-gen Intel NUCs.

This could almost certainly be done more cleanly, and the patches are checked in rather than being pulled in and verified at build time, hence "work in progress".

Tested against NUC7i5BNH hardware, not yet tested against existing hardware recommendations.